### PR TITLE
feat : core io Record-slice data-structures

### DIFF
--- a/src/elastica_pipelines/io/core.py
+++ b/src/elastica_pipelines/io/core.py
@@ -1,9 +1,11 @@
 """Core IO types."""
 from typing import Any
 from typing import Iterator
+from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
+from typing import overload
 
 import numpy.typing as npt
 
@@ -15,9 +17,11 @@ from elastica_pipelines.io.protocols import record_type
 from elastica_pipelines.io.protocols import slice_type
 from elastica_pipelines.io.transforms import Compose
 from elastica_pipelines.io.typing import FuncType
+from elastica_pipelines.io.typing import Indices
 from elastica_pipelines.io.typing import Key
 from elastica_pipelines.io.typing import Node
 from elastica_pipelines.io.typing import Record
+from elastica_pipelines.io.typing import RecordLeafs
 from elastica_pipelines.io.typing import Records
 from elastica_pipelines.io.typing import RecordsSlice
 
@@ -40,7 +44,9 @@ class SystemRecord(Record):
             string based lookup.
     """
 
-    def __init__(self, node: Node, sys_id: int, transforms: Optional[FuncType] = None):
+    def __init__(
+        self, node: Node, sys_id: int, transforms: Optional[FuncType] = None
+    ) -> None:
         """Init."""
         self.node = node
         self.sys_id = sys_id
@@ -127,7 +133,7 @@ class SystemRecords(Records, HasRecordTraits):
     def __len__(self) -> int:  # noqa
         return len(self.node)
 
-    def __getitem__(self, k: Key) -> Union[Record, RecordsSlice]:  # noqa
+    def __getitem__(self, k: Key) -> RecordLeafs:  # noqa
         length = len(self)
         if isinstance(k, int):
             rt: Type[Record] = record_type(self)
@@ -135,7 +141,157 @@ class SystemRecords(Records, HasRecordTraits):
         elif isinstance(k, slice):
             st: Type[RecordsSlice] = slice_type(self)
             return st(self, slice(*k.indices(length)))
+        elif isinstance(k, list):
+            it: Type[RecordsSlice] = slice_type(self)
+            return it(self, k)
         elif isinstance(k, str):
             return self.__getitem__(int(k))
         else:
             raise TypeError(f"Invalid argument type: {type(k)}")
+
+
+class RecordsIndexedOp:
+    """Operations on a discrete indices of a record.
+
+    Args:
+        indices (int, List[int]) : indices on which the record is sliced.
+    """
+
+    def __init__(self, indices: Union[int, List[int]]) -> None:  # noqa
+        self.value = [indices] if isinstance(indices, int) else indices
+
+    def get_length_of_slice(self, length: int) -> int:
+        """Get length of slice.
+
+        Args:
+            length: Length from which we obtain the slice length.
+
+        Returns:
+            Length of the slice.
+        """
+        return len(self.value)
+
+    @overload
+    def get_index_into_slice(self, k: int, length: int) -> int:  # noqa
+        ...  # pragma: no cover
+
+    @overload
+    def get_index_into_slice(self, k: slice, length: int) -> List[int]:  # noqa
+        ...  # pragma: no cover
+
+    @overload
+    def get_index_into_slice(self, k: List[int], length: int) -> List[int]:  # noqa
+        ...  # pragma: no cover
+
+    def get_index_into_slice(self, k: Indices, length: int) -> Union[List[int], int]:
+        """Gets index into slice.
+
+        Args:
+            k (Indices): Set of indices into the record slice.
+            length (int): Length of the record slice.
+
+        Returns:
+            Indices into the record slice.
+        """
+        if isinstance(k, (int, slice)):
+            return self.value[k]
+        else:
+            return [self.value[j] for j in k]
+
+
+class RecordsSliceOp:
+    """Operations on a slice of a record.
+
+    Args:
+        indices (slice) : slice onto which the record is sliced.
+    """
+
+    def __init__(self, indices: slice) -> None:  # noqa
+        self.value = indices
+
+    def get_length_of_slice(self, length: int) -> int:
+        """Get length of slice.
+
+        Args:
+            length: Length from which we obtain the slice length.
+
+        Returns:
+            Length of the slice.
+        """
+        return len(range(*self.value.indices(length)))
+
+    @overload
+    def get_index_into_slice(self, k: int, length: int) -> int:  # noqa
+        ...  # pragma: no cover
+
+    @overload
+    def get_index_into_slice(self, k: slice, length: int) -> slice:  # noqa
+        ...  # pragma: no cover
+
+    @overload
+    def get_index_into_slice(self, k: List[int], length: int) -> List[int]:  # noqa
+        ...  # pragma: no cover
+
+    def get_index_into_slice(self, k: Indices, length: int) -> Indices:
+        """Gets index into slice.
+
+        Args:
+            k (Indices): Set of indices into the record slice.
+            length (int): Length of the record slice.
+
+        Returns:
+            Indices into the record slice.
+        """
+        if isinstance(k, int):
+            return self.value.start + self.value.step * _validate(length, k)
+        elif isinstance(k, slice):
+            c_start, c_stop, c_step = k.indices(length)
+            p_start, _, p_step = self.value.start, self.value.stop, self.value.step
+            start = p_start + p_step * c_start
+            stop = p_start + p_step * c_stop
+            step = p_step * c_step
+            return slice(start, stop, step)
+        else:
+            return [self.get_index_into_slice(j, length) for j in k]
+
+
+class SystemRecordsSlice(RecordsSlice, HasRecordTraits):
+    """Base class for a slice of io.SystemRecords.
+
+    Is intended to be specialized for different Elastica++ data-stuctures via a traits
+    class.
+
+    Args:
+        parent (Records): Parent records object lookup the system records.
+        index (Indices): Datastructure satisfying ``Indices`` requirements.
+    """
+
+    def __init__(self, parent: SystemRecords, indices: Indices) -> None:
+        """Initializer."""
+        self.parent = parent
+        self.indices: Union[RecordsIndexedOp, RecordsSliceOp] = (
+            RecordsSliceOp(indices)
+            if isinstance(indices, slice)
+            else RecordsIndexedOp([indices])
+            if isinstance(indices, int)
+            else RecordsIndexedOp(indices)
+        )
+
+    def __iter__(self) -> Iterator[int]:  # noqa
+        # Implemented as integers from 0 to len() instead of parent to
+        # have consistent API usage.
+        yield from range(len(self))
+
+    def __len__(self) -> int:  # noqa
+        return self.indices.get_length_of_slice(len(self.parent))
+
+    def __getitem__(self, k: Key) -> RecordLeafs:  # noqa
+        if isinstance(k, str):
+            return self.__getitem__(int(k))
+        elif isinstance(k, (int, list, slice)):
+            return self.parent.__getitem__(
+                self.indices.get_index_into_slice(k, len(self))
+            )
+        else:
+            # Parent raises the appropriate error if type is incorrect.
+            return self.parent.__getitem__(k)  # type: ignore[unreachable]

--- a/src/elastica_pipelines/io/protocols.py
+++ b/src/elastica_pipelines/io/protocols.py
@@ -7,7 +7,7 @@ from typing import Type
 
 from typing_extensions import Protocol
 
-from elastica_pipelines.io.typing import Index
+from elastica_pipelines.io.typing import Indices
 from elastica_pipelines.io.typing import Key
 from elastica_pipelines.io.typing import Node
 from elastica_pipelines.io.typing import Record
@@ -92,7 +92,7 @@ class RecordTraits(Protocol):
         """Obtains the system name."""
         ...  # pragma: no cover
 
-    def index_type(self) -> Type[SystemIndex]:
+    def index_type(self) -> Type[SystemIndices]:
         """Obtains type of (system) index."""
         ...  # pragma: no cover
 
@@ -139,7 +139,7 @@ class _ErrorOutTraits:
         """Obtains the system name."""
         self.raise_error()
 
-    def index_type(self) -> Type[SystemIndex]:
+    def index_type(self) -> Type[SystemIndices]:
         """Obtains type of (system) index."""
         return self.raise_error()
 
@@ -192,7 +192,7 @@ def name(x: HasRecordTraits) -> str:
     return x.traits.name()
 
 
-def index_type(x: HasRecordTraits) -> Type[SystemIndex]:
+def index_type(x: HasRecordTraits) -> Type[SystemIndices]:
     """Obtains the type of (system) index.
 
     Args:
@@ -204,7 +204,7 @@ def index_type(x: HasRecordTraits) -> Type[SystemIndex]:
     return x.traits.index_type()
 
 
-class SystemIndex(HasRecordTraits):
+class SystemIndices(HasRecordTraits):
     """Protocol for index into data-records."""
 
-    index: Index
+    indices: Indices

--- a/src/elastica_pipelines/io/typing.py
+++ b/src/elastica_pipelines/io/typing.py
@@ -18,7 +18,7 @@ FuncType: TypeAlias = Callable[..., Any]
 F = TypeVar("F", bound=FuncType)
 
 
-Key: TypeAlias = Union[int, str, slice]
+Key: TypeAlias = Union[int, str, List[int], slice]
 Node: TypeAlias = Mapping[str, Any]
 Indices: TypeAlias = Union[int, slice, List[int]]
 

--- a/src/elastica_pipelines/io/typing.py
+++ b/src/elastica_pipelines/io/typing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Callable
+from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import TypeVar
@@ -19,7 +20,7 @@ F = TypeVar("F", bound=FuncType)
 
 Key: TypeAlias = Union[int, str, slice]
 Node: TypeAlias = Mapping[str, Any]
-Index: TypeAlias = Union[int, slice]
+Indices: TypeAlias = Union[int, slice, List[int]]
 
 
 class _RecordImplementation(Mapping[str, npt.ArrayLike]):
@@ -42,7 +43,7 @@ Records: TypeAlias = _RecordsImplementation
 
 
 class _RecordSliceImplementation(Mapping[Key, RecordLeafs]):
-    def __init__(self, parent: Records, slice: slice) -> None:  # noqa
+    def __init__(self, parent: Records, indices: Indices) -> None:  # noqa
         ...  # pragma: no cover
 
 

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -3,8 +3,11 @@ from typing import Type
 
 import pytest
 
+from elastica_pipelines.io.core import RecordsIndexedOp
+from elastica_pipelines.io.core import RecordsSliceOp
 from elastica_pipelines.io.core import SystemRecord
 from elastica_pipelines.io.core import SystemRecords
+from elastica_pipelines.io.core import SystemRecordsSlice
 from elastica_pipelines.io.core import _validate
 from elastica_pipelines.io.protocols import ElasticaConvention
 from elastica_pipelines.io.typing import Record
@@ -15,7 +18,7 @@ from tests.io.test_protocols import skip_if_env_has
 
 
 @pytest.fixture
-def parent_v():
+def node_v():
     """Get system record parent for testing."""
 
     def node_data(x, y):
@@ -31,73 +34,58 @@ def parent_v():
 class TestSystemRecord:
     """Testing SystemRecord."""
 
-    def test_getitem(self, parent_v) -> None:
+    def test_getitem(self, node_v) -> None:
         """Get test.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
-        s = SystemRecord(parent_v, sys_id=0)
+        s = SystemRecord(node_v, sys_id=0)
         assert s["k1"] == 5
         assert s["k2"] == 10
 
-        ys = SystemRecord(parent_v, sys_id=1)
+        ys = SystemRecord(node_v, sys_id=1)
         assert ys["k1"] == 20
         assert ys["k2"] == 40
 
-    def test_transforms(self, parent_v) -> None:
+    def test_transforms(self, node_v) -> None:
         """Test transformation.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
 
         def trafo(x):
             return x + 2
 
-        s = SystemRecord(parent_v, sys_id=0, transforms=trafo)
+        s = SystemRecord(node_v, sys_id=0, transforms=trafo)
         assert s["k1"] == trafo(5)
         assert s["k2"] == trafo(10)
 
-    def test_len(self, parent_v) -> None:
+    def test_len(self, node_v) -> None:
         """Test length.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
-        s = SystemRecord(parent_v, sys_id=0)
+        s = SystemRecord(node_v, sys_id=0)
         # There are only two keys k1, k2
         assert len(s) == 2
         # Add a keys check to ensure mapping works irrespective
         # of typing or collections.abc
         assert len(s.keys()) > 0
 
-    def test_iter(self, parent_v) -> None:
+    def test_iter(self, node_v) -> None:
         """Test iterator.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
-        s = SystemRecord(parent_v, sys_id=0)
+        s = SystemRecord(node_v, sys_id=0)
         # There are only two keys.
         its = iter(s)
         assert next(its) == "k1"
         assert next(its) == "k2"
-
-
-class _Sink(RecordsSlice):
-    def __init__(self, *args, **kwargs) -> None:  # noqa
-        self.args = args
-        self.kwargs = kwargs
-
-    def __iter__(self):  # noqa
-        ...  # pragma: no cover
-
-    def __len__(self) -> int:  # noqa
-        ...  # pragma: no cover
-
-    def __getitem__(self, k):  # noqa
-        ...  # pragma: no cover
 
 
 class SpecializedTraits(_Traits):
@@ -109,7 +97,7 @@ class SpecializedTraits(_Traits):
 
     def slice_type(self) -> Type[RecordsSlice]:
         """Obtains type of (system) records slice."""
-        return _Sink
+        return SystemRecordsSlice
 
 
 class SpecializedRecords(SystemRecords):
@@ -136,35 +124,35 @@ def test_validate() -> None:
 class TestSystemRecords:
     """Testing SystemRecords."""
 
-    def test_len(self, parent_v) -> None:
+    def test_len(self, node_v) -> None:
         """Test length.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
-        s = SystemRecords(parent_v)
+        s = SystemRecords(node_v)
         # There are three keys : 100, 200, 300
         assert len(s) == 3
         # Add a keys check to ensure mapping works irrespective
         # of typing or collections.abc
         assert len(s.keys()) > 0
 
-    def test_default_traits(self, parent_v) -> None:
+    def test_default_traits(self, node_v) -> None:
         """Test length.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
-        s = SystemRecords(parent_v)
+        s = SystemRecords(node_v)
         run_traits_error_test(s)
 
-    def test_getitem_error(self, parent_v) -> None:
+    def test_getitem_error(self, node_v) -> None:
         """Getitem error test.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
-        s = SystemRecords(parent_v)
+        s = SystemRecords(node_v)
         match = "system record types"
 
         def test_key_raises_error(k):
@@ -183,13 +171,13 @@ class TestSystemRecords:
         # Tests error from the slice method
         test_key_raises_error(slice(None, -1, None))
 
-    def test_iter(self, parent_v) -> None:
+    def test_iter(self, node_v) -> None:
         """Test iterator.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
-        s = SystemRecords(parent_v)
+        s = SystemRecords(node_v)
         # There are three keys
         its = iter(s)
         assert next(its) == 0
@@ -200,37 +188,40 @@ class TestSystemRecords:
         for idx, k in enumerate(s):
             assert k == idx
 
-    def test_getitem(self, parent_v) -> None:
+    def test_getitem(self, node_v) -> None:
         """Getitem error test.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
-        s = SpecializedRecords(parent_v)
+        s = SpecializedRecords(node_v)
 
         # Tests the string key
-        assert s["0"] == SystemRecord(parent_v, 0)
-        assert s["1"] == SystemRecord(parent_v, 1)
-        assert s["2"] == SystemRecord(parent_v, 2)
+        assert s["0"] == SystemRecord(node_v, 0)
+        assert s["1"] == SystemRecord(node_v, 1)
+        assert s["2"] == SystemRecord(node_v, 2)
 
         # Tests the int key
-        assert s[0] == SystemRecord(parent_v, 0)
-        assert s[1] == SystemRecord(parent_v, 1)
-        assert s[2] == SystemRecord(parent_v, 2)
+        assert s[0] == SystemRecord(node_v, 0)
+        assert s[1] == SystemRecord(node_v, 1)
+        assert s[2] == SystemRecord(node_v, 2)
 
         # Tests the slice method
-        # TODO : update with proper slice method
         sl = slice(None, -1, None)
-        sliced = s[sl]
-        assert type(sliced) == _Sink
-        assert sliced.args == (s, slice(*sl.indices(3)))
+        actual = s[sl]
+        expected = SystemRecordsSlice(s, slice(0, 2, 1))
+        assert actual == expected
+
+        # Tests the discrete index method
+        sl = [0, 2]
+        assert s[sl] == SystemRecordsSlice(s, sl)
 
     @skip_if_env_has("typeguard")
-    def test_getitem_type_error(self, parent_v) -> None:
+    def test_getitem_type_error(self, node_v) -> None:
         """Getitem type error test.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
 
         def test_error(s):
@@ -238,18 +229,209 @@ class TestSystemRecords:
                 s[0.02]
             return True
 
-        records = (SystemRecords(parent_v), SpecializedRecords(parent_v))
+        records = (SystemRecords(node_v), SpecializedRecords(node_v))
         assert all(map(test_error, records))
 
-    def test_transforms(self, parent_v) -> None:
+    def test_transforms(self, node_v) -> None:
         """Test transformation.
 
         Args:
-            parent_v : The fixture to obtain parents.
+            node_v : The fixture to obtain parents.
         """
 
         def trafo(x):
             return x + 2
 
-        s = SpecializedRecords(parent_v, transforms=trafo)
-        assert s[0] == SystemRecord(parent_v, 0, trafo)
+        s = SpecializedRecords(node_v, transforms=trafo)
+        assert s[0] == SystemRecord(node_v, 0, trafo)
+
+
+class TestRecordsIndexedOp:
+    """Testing Indexed Records Op."""
+
+    def test_get_length_of_slice(self):
+        """Tests get_length_of_slice()."""
+        dummy_length = 2
+        op = RecordsIndexedOp(1)
+        assert op.get_length_of_slice(dummy_length) == 1
+
+        op = RecordsIndexedOp([1, 2])
+        assert op.get_length_of_slice(dummy_length) == 2
+
+    def test_get_index_into_slice(self):
+        """Tests get_index_into_slice()."""
+        dummy_length = 2
+        op = RecordsIndexedOp(1)
+        assert op.get_index_into_slice(0, dummy_length) == 1
+
+        op = RecordsIndexedOp([1, 2, 3])
+        assert op.get_index_into_slice(0, dummy_length) == 1
+        assert op.get_index_into_slice(1, dummy_length) == 2
+
+        assert op.get_index_into_slice(slice(0, -1, None), dummy_length) == [1, 2]
+
+        assert op.get_index_into_slice([2], dummy_length) == [3]
+
+        def test_error(idx):
+            with pytest.raises(IndexError):
+                op.get_index_into_slice(idx, dummy_length)
+            return True
+
+        error_tests = ([-4], [4], [2, 3])  # , slice(0, 5, 1) : does not raise error
+        assert all(map(test_error, error_tests))
+
+
+class TestRecordsSliceOp:
+    """Testing Sliced Records Op."""
+
+    def test_get_length_of_slice(self):
+        """Tests get_length_of_slice()."""
+        op = RecordsSliceOp(slice(0, 5, 2))
+        assert op.get_length_of_slice(10) == 3  # 0, 2, 4
+        assert op.get_length_of_slice(3) == 2  # 0, 2
+
+        op = RecordsSliceOp(slice(-4, -1, 2))
+        assert op.get_length_of_slice(10) == 2
+        assert op.get_length_of_slice(3) == 1
+
+    def test_index_into_slice(self):
+        """Tests get_index_into_slice()."""
+        op = RecordsSliceOp(slice(0, 5, 2))
+        assert op.get_index_into_slice(0, 10) == 0
+        assert op.get_index_into_slice(1, 10) == 2
+        assert op.get_index_into_slice(2, 10) == 4
+        assert op.get_index_into_slice(2, 4) == 4
+
+        assert op.get_index_into_slice([0, 1], 10) == [0, 2]
+
+        op = RecordsSliceOp(slice(0, 10, 2))  # index into original array
+        length = op.get_length_of_slice(20)  # parent has t=20 records
+        assert op.get_index_into_slice(slice(0, -1, None), length) == slice(0, 8, 2)
+        assert op.get_index_into_slice(slice(0, 2, 1), length) == slice(0, 4, 2)
+        assert op.get_index_into_slice(slice(0, -1, 2), length) == slice(0, 8, 4)
+
+        def test_error(idx):
+            with pytest.raises(KeyError):
+                op.get_index_into_slice(idx, length)
+            return True
+
+        # length is 5
+        error_tests = ([-6], [6], [6, -7])  # , slice(0, 5, 1) : does not raise error
+        assert all(map(test_error, error_tests))
+
+
+class TestSystemRecordsSlice:
+    """Testing SystemRecordsSlice."""
+
+    @pytest.fixture
+    def records_v(self, node_v):
+        """Obtains records from node.
+
+        Args:
+            node_v : The fixture to obtain node.
+
+        Returns:
+            records_v : Specialization of system records.
+        """
+        return SpecializedRecords(node_v)
+
+    def test_len(self, records_v) -> None:
+        """Test length.
+
+        Args:
+            records_v : The fixture to obtain records.
+        """
+        s = records_v[[0, 1]]
+        # There are three keys : 100, 200, 300
+        assert len(s) == 2
+        # Add a keys check to ensure mapping works irrespective
+        # of typing or collections.abc
+        assert len(s.keys()) > 0
+
+    def test_construction(self, records_v) -> None:
+        """Test construction.
+
+        Args:
+            records_v : The fixture to obtain records.
+        """
+        s = records_v[[0, 1]]
+        assert len(s) == 2
+
+        s = records_v[:-1]
+        assert len(s) == 2
+
+        s = records_v[1:-1]
+        assert len(s) == 1
+
+    # def test_traits(self, records_v) -> None:
+    #     """Test traits.
+
+    #     Args:
+    #         records_v : The fixture to obtain parents.
+    #     """
+    #     s = records_v[[0, 1]]
+    #     assert isinstance(s.traits, SpecializedTraits)
+
+    def test_iter(self, records_v) -> None:
+        """Test iterator.
+
+        Args:
+            records_v : The fixture to obtain records.
+        """
+        s = records_v[[1, 2]]
+        # There are three keys
+        its = iter(s)
+        assert next(its) == 0
+        assert next(its) == 1
+
+        # Test iterator directly via yield
+        for idx, k in enumerate(s):
+            assert k == idx
+
+    def test_getitem(self, records_v) -> None:
+        """Getitem test.
+
+        Args:
+            records_v : The fixture to obtain parents.
+        """
+        sl = records_v[[1, 2]]
+
+        # Tests the string key
+        def test(s):
+            assert isinstance(s["0"], SystemRecord)
+            assert s["0"].node == records_v.node
+            assert s["0"].sys_id == 1
+            assert isinstance(s["1"], SystemRecord)
+            assert s["1"].node == records_v.node
+            assert s["1"].sys_id == 2
+
+        test(sl)
+
+        # Tests the int key
+        assert isinstance(sl[0], SystemRecord)
+        assert sl[0].node == records_v.node
+        assert sl[0].sys_id == 1
+
+        sl = records_v[1:]  # (1, 2)
+        # Tests the slice method
+        assert sl[:-1] == SystemRecordsSlice(records_v, slice(1, 2, 1))
+        test(sl[:])
+
+        # Tests the discrete index method
+        test(sl[[0, 1]])
+
+    @skip_if_env_has("typeguard")
+    def test_getitem_type_error(self, records_v) -> None:
+        """Getitem type error test.
+
+        Args:
+            records_v : The fixture to obtain parents.
+        """
+
+        def test_error(s):
+            with pytest.raises(TypeError, match="Invalid argument"):
+                s[0.02]
+            return True
+
+        records = (records_v[[0, 1]], records_v[1:2])
+        assert all(map(test_error, records))

--- a/tests/io/test_protocols.py
+++ b/tests/io/test_protocols.py
@@ -130,7 +130,9 @@ class TestTraits:
         assert fun(arg_type) == SystemIndices
 
 
-def run_traits_error_test(s: HasRecordTraits) -> None:
+def run_traits_error_test(
+    s: HasRecordTraits,
+) -> None:
     """Traits error test.
 
     Args:

--- a/tests/io/test_protocols.py
+++ b/tests/io/test_protocols.py
@@ -7,7 +7,7 @@ import pytest
 
 from elastica_pipelines.io.protocols import ElasticaConvention
 from elastica_pipelines.io.protocols import HasRecordTraits
-from elastica_pipelines.io.protocols import SystemIndex
+from elastica_pipelines.io.protocols import SystemIndices
 from elastica_pipelines.io.protocols import index_type
 from elastica_pipelines.io.protocols import name
 from elastica_pipelines.io.protocols import record_type
@@ -64,9 +64,9 @@ class _Traits:
         """Obtains the system name."""
         return "_Traits"
 
-    def index_type(self) -> Type[SystemIndex]:
+    def index_type(self) -> Type[SystemIndices]:
         """Obtains type of (system) index."""
-        return SystemIndex
+        return SystemIndices
 
 
 def skip_if_env_has(*envs):
@@ -127,7 +127,7 @@ class TestTraits:
         """Test index type."""
         from elastica_pipelines.io.protocols import index_type as fun
 
-        assert fun(arg_type) == SystemIndex
+        assert fun(arg_type) == SystemIndices
 
 
 def run_traits_error_test(s: HasRecordTraits) -> None:


### PR DESCRIPTION
Adds core I/O records data-structures for (lazily) slicing a collection of Elastica++ systems.