### PR TITLE
feat : add agnostic `rods()` to Snapshot

### DIFF
--- a/examples/io_iteration.py
+++ b/examples/io_iteration.py
@@ -26,3 +26,12 @@ for t, snapshot in series.iterations():
             print(f"  {list(rod.keys())}")
         # and then access it values.
         print(f"  Rod '{rod_id}' position:", rod["Position"])
+
+    # To access all rod types (CosseratRod, CosseratRodWithoutDamping etc.),
+    # use the rods() method
+    for (
+        rod_id,
+        rod,
+    ) in snapshot.rods().items():
+        # and then access it values.
+        print(f"  Rod '{rod_id}' position:", rod["Position"])

--- a/tests/io/test_temporal.py
+++ b/tests/io/test_temporal.py
@@ -238,6 +238,21 @@ class TestSnapshot:
 
     # FIXME : Typeguard fails with a weird NameError not related to the test.
     @skip_if_env_has("typeguard")
+    def test_rods(self, snap_node) -> None:
+        """Test rods() call.
+
+        Args:
+            snap_node : The fixture to obtain node data.
+        """
+        s = Snapshot(snap_node)
+
+        sl = s.rods()
+
+        assert len(sl) == (3 + 3)  # Two cosserat rod types
+        assert list(map(lambda x: x.sys_id, sl.keys())) == [0, 1, 2, 0, 1, 2]
+
+    # FIXME : Typeguard fails with a weird NameError not related to the test.
+    @skip_if_env_has("typeguard")
     def test_systems(self, snap_node) -> None:
         """Test systems() call.
 


### PR DESCRIPTION
Adds a `rods()` method to Snapshot to browse all rods in the simulation (e.g. CosseratRod, CosseratRodWithoutDamping, and rod types that maybe added in the future).