### PR TITLE
feat : test and raise errors for non-file inputs

### DIFF
--- a/src/elastica_pipelines/io/entry.py
+++ b/src/elastica_pipelines/io/entry.py
@@ -11,6 +11,23 @@ from elastica_pipelines.io.temporal import Series
 from elastica_pipelines.io.typing import FuncType
 
 
+def _check_ok(p: pathlib.Path) -> None:
+    """Check if input path is okay to read from.
+
+    Args:
+        p(Path) : path of file to choose backend.
+
+    Raises:
+        FileNotFoundError: If p does not exist.
+        OSError: If p is not a file.
+    """
+    if not p.exists():
+        raise FileNotFoundError(f"File in path {p} not found.")
+
+    if not p.is_file():
+        raise OSError(f"Path {p} is not a valid file.")
+
+
 def _choose_backend(p: pathlib.Path) -> SupportedBackends:
     """Choose backend based on file name.
 
@@ -21,14 +38,12 @@ def _choose_backend(p: pathlib.Path) -> SupportedBackends:
         Supported Backend
 
     Raises:
-        FileNotFoundError: If p does not exist.
         RuntimeError: If backend is unsupported.
     """
-    if not p.exists():
-        raise FileNotFoundError(f"File in path {p} not found.")
+    _check_ok(p)
 
     def match(suffix: str) -> bool:
-        return p.is_file() and p.suffix == suffix
+        return p.suffix == suffix
 
     if match(".h5"):
         return SupportedBackends.HDF5

--- a/tests/io/test_entry.py
+++ b/tests/io/test_entry.py
@@ -43,6 +43,12 @@ class TestSeriesEntry:
         with pytest.raises(FileNotFoundError):
             iterate_series_metadata(metadata_file)
 
+    def test_metadata_throw_not_file(self):
+        """Test path inputs."""
+        metadata_file = THIS_DIR / "data"
+        with pytest.raises(IOError):
+            iterate_series_metadata(metadata_file)
+
     def test_metadata_throw_unsupported_backend(self):
         """Test unsupported backend."""
         metadata_file = THIS_DIR / "data" / "elastica_metadata.yml"


### PR DESCRIPTION
Incorrect metadata file paths (such as folders) are now checked rather than returning an "UnsupportedBackendError".